### PR TITLE
[RHM-1969] Gloat should support rollback of migrations.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 build:
 	@mkdir -p bin
-	@go build -o bin/gloat github.com/gsamokovarov/gloat/cmd/gloat
+	@go build -o bin/gloat github.com/webedx-spark/gloat/cmd/gloat
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 
 .PHONY: test.sqlite
 test.sqlite:
-	@env DATABASE_URL=sqlite3://:memory: go test ./...
+	@env DATABASE_SRC=testdata/migrations/ DATABASE_URL=sqlite3://:memory: go test ./...
 
 .PHONY: test.assets
 test.assets:

--- a/assets_test.go
+++ b/assets_test.go
@@ -3,6 +3,11 @@
 // testdata/migrations/20170329154959_introduce_domain_model/down.sql
 // testdata/migrations/20170329154959_introduce_domain_model/up.sql
 // testdata/migrations/20170511172647_irreversible_migration_brah/up.sql
+// testdata/migrations/20180905150724_concurrent_migration/down.sql
+// testdata/migrations/20180905150724_concurrent_migration/options.json
+// testdata/migrations/20180905150724_concurrent_migration/up.sql
+// testdata/migrations/20180920181906_migration_with_an_error/down.sql
+// testdata/migrations/20180920181906_migration_with_an_error/up.sql
 // DO NOT EDIT!
 
 package gloat
@@ -85,7 +90,7 @@ func testdataMigrations20170329154959_introduce_domain_modelDownSql() (*asset, e
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "testdata/migrations/20170329154959_introduce_domain_model/down.sql", size: 18, mode: os.FileMode(420), modTime: time.Unix(1492188343, 0)}
+	info := bindataFileInfo{name: "testdata/migrations/20170329154959_introduce_domain_model/down.sql", size: 18, mode: os.FileMode(420), modTime: time.Unix(1646038365, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -105,7 +110,7 @@ func testdataMigrations20170329154959_introduce_domain_modelUpSql() (*asset, err
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "testdata/migrations/20170329154959_introduce_domain_model/up.sql", size: 266, mode: os.FileMode(420), modTime: time.Unix(1492775179, 0)}
+	info := bindataFileInfo{name: "testdata/migrations/20170329154959_introduce_domain_model/up.sql", size: 266, mode: os.FileMode(420), modTime: time.Unix(1646038365, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -125,7 +130,107 @@ func testdataMigrations20170511172647_irreversible_migration_brahUpSql() (*asset
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "testdata/migrations/20170511172647_irreversible_migration_brah/up.sql", size: 54, mode: os.FileMode(420), modTime: time.Unix(1494518694, 0)}
+	info := bindataFileInfo{name: "testdata/migrations/20170511172647_irreversible_migration_brah/up.sql", size: 54, mode: os.FileMode(420), modTime: time.Unix(1646038365, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testdataMigrations20180905150724_concurrent_migrationDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x01\x00\x00\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00")
+
+func testdataMigrations20180905150724_concurrent_migrationDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		_testdataMigrations20180905150724_concurrent_migrationDownSql,
+		"testdata/migrations/20180905150724_concurrent_migration/down.sql",
+	)
+}
+
+func testdataMigrations20180905150724_concurrent_migrationDownSql() (*asset, error) {
+	bytes, err := testdataMigrations20180905150724_concurrent_migrationDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "testdata/migrations/20180905150724_concurrent_migration/down.sql", size: 0, mode: os.FileMode(420), modTime: time.Unix(1646038365, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testdataMigrations20180905150724_concurrent_migrationOptionsJson = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xaa\xe6\xe2\x54\x2a\x29\x4a\xcc\x2b\x4e\x4c\x2e\xc9\xcc\xcf\x53\xb2\x52\x48\x4b\xcc\x29\x4e\xe5\xaa\xe5\x02\x04\x00\x00\xff\xff\x0e\x77\x70\x04\x1a\x00\x00\x00")
+
+func testdataMigrations20180905150724_concurrent_migrationOptionsJsonBytes() ([]byte, error) {
+	return bindataRead(
+		_testdataMigrations20180905150724_concurrent_migrationOptionsJson,
+		"testdata/migrations/20180905150724_concurrent_migration/options.json",
+	)
+}
+
+func testdataMigrations20180905150724_concurrent_migrationOptionsJson() (*asset, error) {
+	bytes, err := testdataMigrations20180905150724_concurrent_migrationOptionsJsonBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "testdata/migrations/20180905150724_concurrent_migration/options.json", size: 26, mode: os.FileMode(420), modTime: time.Unix(1646038365, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testdataMigrations20180905150724_concurrent_migrationUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x01\x00\x00\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00")
+
+func testdataMigrations20180905150724_concurrent_migrationUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		_testdataMigrations20180905150724_concurrent_migrationUpSql,
+		"testdata/migrations/20180905150724_concurrent_migration/up.sql",
+	)
+}
+
+func testdataMigrations20180905150724_concurrent_migrationUpSql() (*asset, error) {
+	bytes, err := testdataMigrations20180905150724_concurrent_migrationUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "testdata/migrations/20180905150724_concurrent_migration/up.sql", size: 0, mode: os.FileMode(420), modTime: time.Unix(1646038365, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testdataMigrations20180920181906_migration_with_an_errorDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x09\xf2\x0f\x50\x08\x71\x74\xf2\x51\x28\x2d\x4e\x2d\x2a\xb6\xe6\x02\x04\x00\x00\xff\xff\x6b\x44\xa8\xf8\x11\x00\x00\x00")
+
+func testdataMigrations20180920181906_migration_with_an_errorDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		_testdataMigrations20180920181906_migration_with_an_errorDownSql,
+		"testdata/migrations/20180920181906_migration_with_an_error/down.sql",
+	)
+}
+
+func testdataMigrations20180920181906_migration_with_an_errorDownSql() (*asset, error) {
+	bytes, err := testdataMigrations20180920181906_migration_with_an_errorDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "testdata/migrations/20180920181906_migration_with_an_error/down.sql", size: 17, mode: os.FileMode(420), modTime: time.Unix(1646038365, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testdataMigrations20180920181906_migration_with_an_errorUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x0e\x72\x75\x0c\x71\x55\x08\x71\x74\xf2\x51\x28\x2d\x4e\x2d\x2a\x56\xd0\xe0\x52\x50\x50\x50\xc8\x4c\x51\x48\xca\x4c\x2f\x4e\x2d\xca\x4c\xcc\x51\x08\x08\xf2\xf4\x75\x0c\x8a\x54\xf0\x76\x8d\x54\xf0\xf3\x0f\x51\xf0\x0b\xf5\xf1\xe1\xd2\xb4\xe6\xe2\x02\x04\x00\x00\xff\xff\x59\x13\xa0\x89\x3e\x00\x00\x00")
+
+func testdataMigrations20180920181906_migration_with_an_errorUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		_testdataMigrations20180920181906_migration_with_an_errorUpSql,
+		"testdata/migrations/20180920181906_migration_with_an_error/up.sql",
+	)
+}
+
+func testdataMigrations20180920181906_migration_with_an_errorUpSql() (*asset, error) {
+	bytes, err := testdataMigrations20180920181906_migration_with_an_errorUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "testdata/migrations/20180920181906_migration_with_an_error/up.sql", size: 62, mode: os.FileMode(420), modTime: time.Unix(1646038365, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -185,6 +290,11 @@ var _bindata = map[string]func() (*asset, error){
 	"testdata/migrations/20170329154959_introduce_domain_model/down.sql": testdataMigrations20170329154959_introduce_domain_modelDownSql,
 	"testdata/migrations/20170329154959_introduce_domain_model/up.sql": testdataMigrations20170329154959_introduce_domain_modelUpSql,
 	"testdata/migrations/20170511172647_irreversible_migration_brah/up.sql": testdataMigrations20170511172647_irreversible_migration_brahUpSql,
+	"testdata/migrations/20180905150724_concurrent_migration/down.sql": testdataMigrations20180905150724_concurrent_migrationDownSql,
+	"testdata/migrations/20180905150724_concurrent_migration/options.json": testdataMigrations20180905150724_concurrent_migrationOptionsJson,
+	"testdata/migrations/20180905150724_concurrent_migration/up.sql": testdataMigrations20180905150724_concurrent_migrationUpSql,
+	"testdata/migrations/20180920181906_migration_with_an_error/down.sql": testdataMigrations20180920181906_migration_with_an_errorDownSql,
+	"testdata/migrations/20180920181906_migration_with_an_error/up.sql": testdataMigrations20180920181906_migration_with_an_errorUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -235,6 +345,15 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			}},
 			"20170511172647_irreversible_migration_brah": &bintree{nil, map[string]*bintree{
 				"up.sql": &bintree{testdataMigrations20170511172647_irreversible_migration_brahUpSql, map[string]*bintree{}},
+			}},
+			"20180905150724_concurrent_migration": &bintree{nil, map[string]*bintree{
+				"down.sql": &bintree{testdataMigrations20180905150724_concurrent_migrationDownSql, map[string]*bintree{}},
+				"options.json": &bintree{testdataMigrations20180905150724_concurrent_migrationOptionsJson, map[string]*bintree{}},
+				"up.sql": &bintree{testdataMigrations20180905150724_concurrent_migrationUpSql, map[string]*bintree{}},
+			}},
+			"20180920181906_migration_with_an_error": &bintree{nil, map[string]*bintree{
+				"down.sql": &bintree{testdataMigrations20180920181906_migration_with_an_errorDownSql, map[string]*bintree{}},
+				"up.sql": &bintree{testdataMigrations20180920181906_migration_with_an_errorUpSql, map[string]*bintree{}},
 			}},
 		}},
 	}},

--- a/cmd/gloat/main.go
+++ b/cmd/gloat/main.go
@@ -141,7 +141,7 @@ func presentCmd(args arguments) error {
 	for i, m := range migrations {
 		fmt.Printf("%d", m.Version)
 		if i != len(migrations)-1 {
-			fmt.Print(", ")
+			fmt.Print(",")
 		}
 	}
 

--- a/cmd/gloat/main.go
+++ b/cmd/gloat/main.go
@@ -150,7 +150,7 @@ func toCmd(args arguments) error {
 		return errors.New("migrate to requires a version to migrate to")
 	}
 
-	version, err := strconv.ParseInt(s, 10, 64)
+	version, err := strconv.ParseInt(args[1], 10, 64)
 	if err != nil {
 		return err
 	}

--- a/cmd/gloat/main.go
+++ b/cmd/gloat/main.go
@@ -138,6 +138,8 @@ func presentCmd(args arguments) error {
 		return err
 	}
 
+	migrations.Sort()
+
 	for i, m := range migrations {
 		fmt.Printf("%d", m.Version)
 		if i != len(migrations)-1 {

--- a/cmd/gloat/main.go
+++ b/cmd/gloat/main.go
@@ -62,7 +62,7 @@ func main() {
 	case "new":
 		err = newCmd(args)
 	case "to":
-		err = toCmd(args)
+		err = migrateToCmd(args)
 	case "latest":
 		err = latestCmd(args)
 	case "current":
@@ -165,7 +165,7 @@ func currentCmd(args arguments) error {
 	return nil
 }
 
-func toCmd(args arguments) error {
+func migrateToCmd(args arguments) error {
 	gl, err := setupGloat(args)
 	if err != nil {
 		return err

--- a/executor_test.go
+++ b/executor_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gsamokovarov/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSQLExecutor_Up(t *testing.T) {

--- a/gloat.go
+++ b/gloat.go
@@ -25,6 +25,11 @@ func (c *Gloat) AppliedAfter(version int64) (Migrations, error) {
 	return AppliedAfter(c.Store, c.Source, version)
 }
 
+// Present returns all available migrations.
+func (c *Gloat) Present() (Migrations, error) {
+	return c.Source.Collect()
+}
+
 // Unapplied returns the unapplied migrations in the current gloat.
 func (c *Gloat) Unapplied() (Migrations, error) {
 	return UnappliedMigrations(c.Store, c.Source)

--- a/gloat.go
+++ b/gloat.go
@@ -16,6 +16,13 @@ type Gloat struct {
 	// Executor applies migrations and marks the newly applied migration
 	// versions in the Store.
 	Executor Executor
+
+	VersionTag string
+}
+
+// AppliedAfter returns migrations that were applied after a given version tag
+func (c *Gloat) AppliedAfter(versionTag string) (Migrations, error) {
+	return AppliedAfter(c.Store, c.Source, versionTag)
 }
 
 // Unapplied returns the unapplied migrations in the current gloat.
@@ -48,6 +55,7 @@ func (c *Gloat) Current() (*Migration, error) {
 		migration := availableMigrations[i]
 
 		if migration.Version == currentMigration.Version {
+			migration.VersionTag = currentMigration.VersionTag
 			return migration, nil
 		}
 	}
@@ -57,6 +65,7 @@ func (c *Gloat) Current() (*Migration, error) {
 
 // Apply applies a migration.
 func (c *Gloat) Apply(migration *Migration) error {
+	migration.VersionTag = c.VersionTag
 	return c.Executor.Up(migration, c.Store)
 }
 

--- a/gloat.go
+++ b/gloat.go
@@ -29,7 +29,7 @@ func (c *Gloat) AppliedAfter(version int64) (Migrations, error) {
 func (c *Gloat) Present() (Migrations, error) {
 	migrations, err := c.Source.Collect()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	migrations.Sort()
 	return migrations, nil

--- a/gloat.go
+++ b/gloat.go
@@ -21,7 +21,7 @@ type Gloat struct {
 }
 
 // AppliedAfter returns migrations that were applied after a given version tag
-func (c *Gloat) AppliedAfter(version int) (Migrations, error) {
+func (c *Gloat) AppliedAfter(version int64) (Migrations, error) {
 	return AppliedAfter(c.Store, c.Source, version)
 }
 

--- a/gloat.go
+++ b/gloat.go
@@ -2,6 +2,7 @@ package gloat
 
 import (
 	"database/sql"
+	"time"
 )
 
 // Gloat glues all the components needed to apply and revert
@@ -86,6 +87,7 @@ func (c *Gloat) Current() (*Migration, error) {
 
 // Apply applies a migration.
 func (c *Gloat) Apply(migration *Migration) error {
+	migration.AppliedAt = time.Now().UTC()
 	return c.Executor.Up(migration, c.Store)
 }
 

--- a/gloat.go
+++ b/gloat.go
@@ -27,7 +27,12 @@ func (c *Gloat) AppliedAfter(version int64) (Migrations, error) {
 
 // Present returns all available migrations.
 func (c *Gloat) Present() (Migrations, error) {
-	return c.Source.Collect()
+	migrations, err := c.Source.Collect()
+	if err != nil {
+		return err
+	}
+	migrations.Sort()
+	return migrations, nil
 }
 
 // Unapplied returns the unapplied migrations in the current gloat.

--- a/gloat_test.go
+++ b/gloat_test.go
@@ -199,6 +199,7 @@ func TestCurrent_Nil(t *testing.T) {
 func TestApply(t *testing.T) {
 	called := false
 
+	m := &Migration{}
 	gl.Store = &testingStore{}
 	gl.Executor = &stubbedExecutor{
 		up: func(*Migration, Store) error {
@@ -207,9 +208,10 @@ func TestApply(t *testing.T) {
 		},
 	}
 
-	gl.Apply(nil)
+	gl.Apply(m)
 
 	assert.True(t, called)
+	assert.NotEmpty(t, m.AppliedAt)
 }
 
 func TestRevert(t *testing.T) {

--- a/gloat_test.go
+++ b/gloat_test.go
@@ -10,9 +10,9 @@ import (
 
 	// Needed to establish database connections during testing.
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/gsamokovarov/assert"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -90,9 +90,9 @@ func TestUnapplied(t *testing.T) {
 
 	migrations, err := gl.Unapplied()
 	assert.Nil(t, err)
-	assert.Len(t, 4, migrations)
+	assert.Len(t, migrations, 4)
 
-	assert.Equal(t, 20170329154959, migrations[0].Version)
+	assert.Equal(t, int64(20170329154959), migrations[0].Version)
 }
 
 func TestUnapplied_Empty(t *testing.T) {
@@ -108,7 +108,7 @@ func TestUnapplied_Empty(t *testing.T) {
 	migrations, err := gl.Unapplied()
 	assert.Nil(t, err)
 
-	assert.Len(t, 0, migrations)
+	assert.Len(t, migrations, 0)
 }
 
 func TestUnapplied_MissingInSource(t *testing.T) {
@@ -128,7 +128,7 @@ func TestUnapplied_MissingInSource(t *testing.T) {
 	migrations, err := gl.Unapplied()
 	assert.Nil(t, err)
 
-	assert.Len(t, 0, migrations)
+	assert.Len(t, migrations, 0)
 }
 
 func TestCurrent(t *testing.T) {
@@ -142,7 +142,23 @@ func TestCurrent(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.NotNil(t, migration)
-	assert.Equal(t, 20170329154959, migration.Version)
+	assert.Equal(t, int64(20170329154959), migration.Version)
+}
+
+func TestLatest(t *testing.T) {
+	gl.Source = &testingStore{
+		applied: Migrations{
+			&Migration{Version: 20190329154959},
+			&Migration{Version: 20180329154959},
+			&Migration{Version: 20170329154959},
+		},
+	}
+
+	migration, err := gl.Latest()
+	assert.Nil(t, err)
+
+	assert.NotNil(t, migration)
+	assert.Equal(t, int64(20190329154959), migration.Version)
 }
 
 func TestCurrent_Nil(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/go-sql-driver/mysql v1.4.0
 	github.com/lib/pq v1.0.0
 	github.com/mattn/go-sqlite3 v1.9.0
-	github.com/stretchr/testify v1.7.1
+	github.com/stretchr/testify v1.7.0
 	google.golang.org/appengine v1.6.7 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/go-sql-driver/mysql v1.4.0
-	github.com/gsamokovarov/assert v0.0.0-20180414063448-8cd8ab63a335
 	github.com/lib/pq v1.0.0
 	github.com/mattn/go-sqlite3 v1.9.0
-	github.com/stretchr/testify v1.7.1 // indirect
+	github.com/stretchr/testify v1.7.1
+	google.golang.org/appengine v1.6.7 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gsamokovarov/gloat
+module github.com/webedx-spark/gloat
 
 require (
 	github.com/go-sql-driver/mysql v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/webedx-spark/gloat
 
+go 1.16
+
 require (
 	github.com/go-sql-driver/mysql v1.4.0
 	github.com/gsamokovarov/assert v0.0.0-20180414063448-8cd8ab63a335
 	github.com/lib/pq v1.0.0
 	github.com/mattn/go-sqlite3 v1.9.0
+	github.com/stretchr/testify v1.7.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOq
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx+opk=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/gsamokovarov/assert v0.0.0-20180414063448-8cd8ab63a335 h1:MFE3iUApg9Sl5MmZnosCEhYXRQCKz5coShpoAF86IiE=
@@ -6,3 +8,11 @@ github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mattn/go-sqlite3 v1.9.0 h1:pDRiWfl+++eC2FEFRy6jXmQlvp4Yh3z1MJKg4UeYM/4=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx+opk=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
-github.com/gsamokovarov/assert v0.0.0-20180414063448-8cd8ab63a335 h1:MFE3iUApg9Sl5MmZnosCEhYXRQCKz5coShpoAF86IiE=
-github.com/gsamokovarov/assert v0.0.0-20180414063448-8cd8ab63a335/go.mod h1:ejyiK4+/RLW9C/QgBK+nlwDmNB9pIW9i2WVqMmAa7no=
+github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mattn/go-sqlite3 v1.9.0 h1:pDRiWfl+++eC2FEFRy6jXmQlvp4Yh3z1MJKg4UeYM/4=
@@ -13,6 +12,15 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
+google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/migration.go
+++ b/migration.go
@@ -89,7 +89,7 @@ func MigrationFromBytes(path string, read func(string) ([]byte, error)) (*Migrat
 		Path:      path,
 		Version:   version,
 		Options:   options,
-		AppliedAt: time.Now().UTC(),
+		AppliedAt: time.Time{},
 	}, nil
 }
 

--- a/migration.go
+++ b/migration.go
@@ -1,6 +1,7 @@
 package gloat
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -22,11 +23,12 @@ var (
 // determine the order of which the migrations would be executed. The path is
 // the name in a store.
 type Migration struct {
-	UpSQL   []byte
-	DownSQL []byte
-	Path    string
-	Version int64
-	Options MigrationOptions
+	UpSQL      []byte
+	DownSQL    []byte
+	Path       string
+	Version    int64
+	VersionTag string
+	Options    MigrationOptions
 }
 
 // Reversible returns true if the migration DownSQL content is present. E.g. if
@@ -116,20 +118,48 @@ type Migrations []*Migration
 // Except selects migrations that does not exist in the current ones.
 func (m Migrations) Except(migrations Migrations) (excepted Migrations) {
 	// Mark the current transactions.
-	current := make(map[int64]bool)
+	current := make(map[int64]string)
 	for _, migration := range m {
-		current[migration.Version] = true
+		current[migration.Version] = migration.VersionTag
 	}
 
 	// Mark the ones in the migrations set, which we do have to get.
-	new := make(map[int64]bool)
+	new := make(map[int64]string)
 	for _, migration := range migrations {
-		new[migration.Version] = true
+		new[migration.Version] = migration.VersionTag
 	}
 
 	for _, migration := range migrations {
-		if new[migration.Version] && !current[migration.Version] {
+		_, will := new[migration.Version]
+		_, has := current[migration.Version]
+		if will && !has {
 			excepted = append(excepted, migration)
+		}
+	}
+
+	return
+}
+
+// Intersect selects migrations that does exist in the current ones.
+func (m Migrations) Intersect(migrations Migrations) (intersect Migrations) {
+	// Mark the current transactions.
+	store := make(map[int64]string)
+	for _, migration := range m {
+		store[migration.Version] = migration.VersionTag
+	}
+
+	// Mark the ones in the migrations set, which we do have to get.
+	source := make(map[int64]string)
+	for _, migration := range migrations {
+		source[migration.Version] = migration.VersionTag
+	}
+
+	for _, migration := range migrations {
+		_, will := source[migration.Version]
+		versionTag, has := store[migration.Version]
+		if will && has {
+			migration.VersionTag = versionTag
+			intersect = append(intersect, migration)
 		}
 	}
 
@@ -145,6 +175,9 @@ func (m Migrations) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 // Sort is a convenience sorting method.
 func (m Migrations) Sort() { sort.Sort(m) }
 
+// ReverseSort is a convenience sorting method.
+func (m Migrations) ReverseSort() { sort.Sort(sort.Reverse(m)) }
+
 // Current returns the latest applied migration. Can be nil, if the migrations
 // are empty.
 func (m Migrations) Current() *Migration {
@@ -155,6 +188,37 @@ func (m Migrations) Current() *Migration {
 	}
 
 	return m[len(m)-1]
+}
+
+// AppliedAfter selects the applied migrations from a Store after a given versionTag.
+func AppliedAfter(store Source, source Source, versionTag string) (Migrations, error) {
+	var appliedAfter Migrations
+	appliedMigrations, err := store.Collect()
+	if err != nil {
+		return nil, err
+	}
+
+	found := false
+	for _, migration := range appliedMigrations {
+		if migration.VersionTag == versionTag {
+			found = true
+			break
+		}
+		appliedAfter = append(appliedAfter, migration)
+	}
+	if !found {
+		return nil, errors.New("versionTag not found")
+	}
+	appliedAfter.ReverseSort()
+
+	availableMigrations, err := source.Collect()
+	if err != nil {
+		return nil, err
+	}
+
+	intersect := appliedAfter.Intersect(availableMigrations)
+	intersect.ReverseSort()
+	return intersect, nil
 }
 
 // UnappliedMigrations selects the unapplied migrations from a Source. For a

--- a/migration.go
+++ b/migration.go
@@ -91,7 +91,7 @@ func MigrationFromBytes(path string, read func(string) ([]byte, error)) (*Migrat
 		Path:      path,
 		Version:   version,
 		Options:   options,
-		AppliedAt: time.UTC(),
+		AppliedAt: time.Now(),
 	}, nil
 }
 

--- a/migration.go
+++ b/migration.go
@@ -91,7 +91,7 @@ func MigrationFromBytes(path string, read func(string) ([]byte, error)) (*Migrat
 		Path:      path,
 		Version:   version,
 		Options:   options,
-		AppliedAt: time.Time{0},
+		AppliedAt: time.UTC(),
 	}, nil
 }
 

--- a/migration.go
+++ b/migration.go
@@ -213,7 +213,7 @@ func AppliedAfter(store Source, source Source, version int64) (Migrations, error
 	}
 
 	found := false
-	for i := 0; i <= len(appliedMigrations); i++ {
+	for i := 0; i < len(appliedMigrations); i++ {
 		if appliedMigrations[i].Version == version {
 			found = true
 			break

--- a/migration_options_test.go
+++ b/migration_options_test.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/gsamokovarov/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaultMigrationOptions(t *testing.T) {

--- a/migration_test.go
+++ b/migration_test.go
@@ -3,8 +3,9 @@ package gloat
 import (
 	"io/ioutil"
 	"testing"
+	"time"
 
-	"github.com/gsamokovarov/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMigrationReversible(t *testing.T) {
@@ -34,7 +35,7 @@ func TestMigrationFromPath(t *testing.T) {
 	m, err := MigrationFromBytes(expectedPath, ioutil.ReadFile)
 	assert.Nil(t, err)
 
-	assert.Equal(t, 20170329154959, m.Version)
+	assert.Equal(t, int64(20170329154959), m.Version)
 	assert.Equal(t, expectedPath, m.Path)
 }
 
@@ -52,5 +53,83 @@ func TestMigrationsExcept(t *testing.T) {
 	assert.Nil(t, exceptedMigrations)
 
 	exceptedMigrations = migrations.Except(Migrations{m})
-	assert.Len(t, 0, exceptedMigrations)
+	assert.Len(t, exceptedMigrations, 0)
+}
+
+func TestMigrationsIntersect(t *testing.T) {
+	var migrations Migrations
+
+	first := "testdata/migrations/20170329154959_introduce_domain_model"
+
+	m1, err := MigrationFromBytes(first, ioutil.ReadFile)
+	assert.Nil(t, err)
+
+	second := "testdata/migrations/20180905150724_concurrent_migration"
+
+	m2, err := MigrationFromBytes(second, ioutil.ReadFile)
+	assert.Nil(t, err)
+
+	migrations = append(migrations, m1)
+	migrations = append(migrations, m2)
+
+	result := migrations.Intersect(nil)
+	assert.Len(t, result, 0)
+
+	result = migrations.Intersect(Migrations{m1})
+	assert.Len(t, result, 1)
+
+	result = migrations.Intersect(Migrations{m1, m2})
+	assert.Len(t, result, 2)
+}
+
+func TestMigrationsSort(t *testing.T) {
+	var migrations Migrations
+
+	first := "testdata/migrations/20170329154959_introduce_domain_model"
+
+	m1, err := MigrationFromBytes(first, ioutil.ReadFile)
+	assert.Nil(t, err)
+
+	second := "testdata/migrations/20180905150724_concurrent_migration"
+
+	m2, err := MigrationFromBytes(second, ioutil.ReadFile)
+	assert.Nil(t, err)
+
+	migrations = append(migrations, m2)
+	migrations = append(migrations, m1)
+
+	migrations.Sort()
+	assert.Equal(t, migrations[0].Version, m1.Version)
+
+	m1.AppliedAt = time.Now().UTC()
+	m2.AppliedAt = m1.AppliedAt.Add(-1 * time.Hour)
+
+	migrations.Sort()
+	assert.Equal(t, migrations[0].Version, m2.Version)
+}
+
+func TestMigrationsReverseSort(t *testing.T) {
+	var migrations Migrations
+
+	first := "testdata/migrations/20170329154959_introduce_domain_model"
+
+	m1, err := MigrationFromBytes(first, ioutil.ReadFile)
+	assert.Nil(t, err)
+
+	second := "testdata/migrations/20180905150724_concurrent_migration"
+
+	m2, err := MigrationFromBytes(second, ioutil.ReadFile)
+	assert.Nil(t, err)
+
+	migrations = append(migrations, m2)
+	migrations = append(migrations, m1)
+
+	migrations.ReverseSort()
+	assert.Equal(t, migrations[0].Version, m2.Version)
+
+	m1.AppliedAt = time.Now().UTC()
+	m2.AppliedAt = m1.AppliedAt.Add(time.Hour)
+
+	migrations.ReverseSort()
+	assert.Equal(t, migrations[0].Version, m2.Version)
 }

--- a/source_test.go
+++ b/source_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gsamokovarov/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFileSystemSourceCollect(t *testing.T) {
@@ -38,7 +38,7 @@ func TestFileSystemSourceCollectEmpty(t *testing.T) {
 	migrations, err := fs.Collect()
 	assert.Nil(t, err)
 
-	assert.Len(t, 0, migrations)
+	assert.Len(t, migrations, 0)
 }
 
 func TestAssetSourceDoesNotBreakOnIrreversibleMigrations(t *testing.T) {
@@ -48,5 +48,5 @@ func TestAssetSourceDoesNotBreakOnIrreversibleMigrations(t *testing.T) {
 	migrations, err := fs.Collect()
 	assert.Nil(t, err)
 
-	assert.Len(t, 2, migrations)
+	assert.Len(t, migrations, 4)
 }

--- a/store.go
+++ b/store.go
@@ -133,7 +133,7 @@ func NewMySQLStore(db SQLTransactor) Store {
 			DELETE FROM schema_migrations
 			WHERE version=?`,
 		selectAllMigrationsStatement: `
-			SELECT version, version_tag
+			SELECT version, applied_at
 			FROM schema_migrations
 			ORDER BY applied_at DESC, version DESC`,
 	}

--- a/store_test.go
+++ b/store_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gsamokovarov/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDatabaseStore_Insert(t *testing.T) {
@@ -30,7 +30,7 @@ func TestDatabaseStore_Insert(t *testing.T) {
 		err = db.QueryRow(`SELECT version FROM schema_migrations`).Scan(&version)
 		assert.Nil(t, err)
 
-		assert.Equal(t, 20170329154959, version)
+		assert.Equal(t, int64(20170329154959), version)
 	})
 }
 
@@ -77,6 +77,6 @@ func TestDatabaseStore_Collect(t *testing.T) {
 			&Migration{Version: 20170329154959},
 		}
 
-		assert.Equal(t, migrations, expectedMigrations)
+		assert.Equal(t, migrations[0].Version, expectedMigrations[0].Version)
 	})
 }


### PR DESCRIPTION
For rhyme to be able to rollback to a prior version our migrations library was forked and additional features were implemented.
There are two possible ways for reverting migrations between versions:
1. If both version are on the same base `migrate to <version>` can be used. In that case migrations applied after `<version>` will be reverted.
- to get the latest migration that is part of a given version, there is `migrate latest` command.
- for correct ordering of migrations `applied_at` field is being added to the database.
3. If the two versions are not part of the same node and their migrations may be applied out of order, the `migrate keep <list,of,versions,to,keep>` can be used. In that case, all migrations listed (in the comma separated list) will be kept, the rest that are applied will be reverted.
- to generate the list of migrations that are part of a given version, there is `migrate present` command.
- for correct ordering of migrations `applied_at` field is being added to the database.


To deploy this feature, the changes of the `schema_migrations` table should be executed manually:
```
ALTER TABLE schema_migrations 
ADD COLUMN applied_at timestamp without time zone default (now() at time zone 'utc');

CREATE INDEX IF NOT EXISTS schema_migrations_applied_at 
ON schema_migrations (applied_at);

```
https://coursera.atlassian.net/browse/RHM-1969

TODO:

- [x] tests
- [x] update help
- [X] write deployment steps

